### PR TITLE
Use more specific event IDs to avoid duplication

### DIFF
--- a/lib/solidus_tracking/event/cancelled_order.rb
+++ b/lib/solidus_tracking/event/cancelled_order.rb
@@ -15,7 +15,7 @@ module SolidusTracking
 
       def properties
         Serializer::Order.serialize(order).merge(
-          '$event_id' => order.id.to_s,
+          '$event_id' => order.number,
           '$value' => order.total,
         )
       end

--- a/lib/solidus_tracking/event/created_account.rb
+++ b/lib/solidus_tracking/event/created_account.rb
@@ -15,7 +15,7 @@ module SolidusTracking
 
       def properties
         Serializer::User.serialize(user).merge(
-          '$event_id' => user.id.to_s,
+          '$event_id' => "#{user.id}-#{user.created_at.to_i}",
         )
       end
 

--- a/lib/solidus_tracking/event/fulfilled_order.rb
+++ b/lib/solidus_tracking/event/fulfilled_order.rb
@@ -15,7 +15,7 @@ module SolidusTracking
 
       def properties
         Serializer::Order.serialize(order).merge(
-          '$event_id' => order.id.to_s,
+          '$event_id' => order.number,
           '$value' => order.total,
         )
       end

--- a/lib/solidus_tracking/event/ordered_product.rb
+++ b/lib/solidus_tracking/event/ordered_product.rb
@@ -17,7 +17,7 @@ module SolidusTracking
 
       def properties
         Serializer::LineItem.serialize(line_item).merge(
-          '$event_id' => line_item.id.to_s,
+          '$event_id' => "#{line_item.order.number}-#{line_item.id}",
           '$value' => line_item.amount,
         )
       end

--- a/lib/solidus_tracking/event/placed_order.rb
+++ b/lib/solidus_tracking/event/placed_order.rb
@@ -15,7 +15,7 @@ module SolidusTracking
 
       def properties
         Serializer::Order.serialize(order).merge(
-          '$event_id' => order.id.to_s,
+          '$event_id' => order.number,
           '$value' => order.total,
         )
       end

--- a/lib/solidus_tracking/event/started_checkout.rb
+++ b/lib/solidus_tracking/event/started_checkout.rb
@@ -15,7 +15,7 @@ module SolidusTracking
 
       def properties
         Serializer::Order.serialize(order).merge(
-          '$event_id' => order.id.to_s,
+          '$event_id' => order.number,
           '$value' => order.total,
         )
       end

--- a/spec/solidus_tracking/event/cancelled_order_spec.rb
+++ b/spec/solidus_tracking/event/cancelled_order_spec.rb
@@ -57,7 +57,7 @@ RSpec.describe SolidusTracking::Event::CancelledOrder do
       event = described_class.new(order: order)
 
       expect(event.properties).to include(
-        '$event_id' => order.id.to_s,
+        '$event_id' => order.number,
         '$value' => order.total,
       )
     end

--- a/spec/solidus_tracking/event/fulfilled_order_spec.rb
+++ b/spec/solidus_tracking/event/fulfilled_order_spec.rb
@@ -71,7 +71,7 @@ RSpec.describe SolidusTracking::Event::FulfilledOrder do
 
       event = described_class.new(order: order)
 
-      expect(event.time).to eq(shipment1.shipped_at)
+      expect(event.time).to eq(shipment1.reload.shipped_at)
     end
   end
 end

--- a/spec/solidus_tracking/event/fulfilled_order_spec.rb
+++ b/spec/solidus_tracking/event/fulfilled_order_spec.rb
@@ -57,7 +57,7 @@ RSpec.describe SolidusTracking::Event::FulfilledOrder do
       event = described_class.new(order: order)
 
       expect(event.properties).to include(
-        '$event_id' => order.id.to_s,
+        '$event_id' => order.number,
         '$value' => order.total,
       )
     end

--- a/spec/solidus_tracking/event/ordered_product_spec.rb
+++ b/spec/solidus_tracking/event/ordered_product_spec.rb
@@ -57,7 +57,7 @@ RSpec.describe SolidusTracking::Event::OrderedProduct do
       event = described_class.new(line_item: line_item)
 
       expect(event.properties).to include(
-        '$event_id' => line_item.id.to_s,
+        '$event_id' => "#{line_item.order.number}-#{line_item.id}",
         '$value' => line_item.amount,
       )
     end

--- a/spec/solidus_tracking/event/placed_order_spec.rb
+++ b/spec/solidus_tracking/event/placed_order_spec.rb
@@ -57,7 +57,7 @@ RSpec.describe SolidusTracking::Event::PlacedOrder do
       event = described_class.new(order: order)
 
       expect(event.properties).to include(
-        '$event_id' => order.id.to_s,
+        '$event_id' => order.number,
         '$value' => order.total,
       )
     end

--- a/spec/solidus_tracking/event/started_checkout_spec.rb
+++ b/spec/solidus_tracking/event/started_checkout_spec.rb
@@ -57,7 +57,7 @@ RSpec.describe SolidusTracking::Event::StartedCheckout do
       event = described_class.new(order: order)
 
       expect(event.properties).to include(
-        '$event_id' => order.id.to_s,
+        '$event_id' => order.number,
         '$value' => order.total,
       )
     end


### PR DESCRIPTION
Adds more specifiers to event IDs, to avoid duplication between event name/ID combinations when testing the application across different environments (e.g., staging and production).