### PR TITLE
Fix recursive loop with persisted payment sources

### DIFF
--- a/bin/rails-sandbox
+++ b/bin/rails-sandbox
@@ -5,12 +5,10 @@ app_root = 'sandbox'
 unless File.exist? "#{app_root}/bin/rails"
   warn 'Creating the sandbox app...'
   Dir.chdir "#{__dir__}/.." do
-    # rubocop:disable Style/RedundantBegin
     system "#{__dir__}/sandbox" or begin
       warn 'Automatic creation of the sandbox app failed'
       exit 1
     end
-    # rubocop:enable Style/RedundantBegin
   end
 end
 

--- a/lib/solidus_tracking/serializer/payment_source.rb
+++ b/lib/solidus_tracking/serializer/payment_source.rb
@@ -11,7 +11,7 @@ module SolidusTracking
         return unless source.is_a?(::Spree::CreditCard)
 
         {
-          'Type' => source.class,
+          'Type' => source.class.to_s,
           'CcType' => source.cc_type,
           'Month' => source.month,
           'Year' => source.year,

--- a/spec/solidus_tracking/serializer/payment_source_spec.rb
+++ b/spec/solidus_tracking/serializer/payment_source_spec.rb
@@ -8,4 +8,12 @@ RSpec.describe SolidusTracking::Serializer::PaymentSource do
       expect(described_class.serialize(payment_source)).to be_instance_of(Hash)
     end
   end
+
+  describe 'the serialized output' do
+    it 'can be converted to JSON when the payment source is persisted to the database' do
+      credit_card = create(:credit_card)
+
+      expect { described_class.serialize(credit_card).to_json }.not_to raise_error
+    end
+  end
 end


### PR DESCRIPTION
This change aims to resolve an issue with converting the result of an order serialization to JSON via `Hash#to_json`.

Having the PaymentSource Type stored as a `Class` would cause an infinite recursive loop, exhausting the system stack. This could be easily missed in specs because using orders, even with payments, not persisted to the database wouldn't raise any error.