### PR TITLE
Allow serializers to be configured on a per-event basis

### DIFF
--- a/lib/solidus_tracking/event/base.rb
+++ b/lib/solidus_tracking/event/base.rb
@@ -5,6 +5,19 @@ module SolidusTracking
     class Base
       attr_reader :payload
 
+      class << self
+        attr_writer :customer_properties_serializer, :payload_serializer
+
+        def customer_properties_serializer
+          @customer_properties_serializer ||= '::SolidusTracking::Serializer::CustomerProperties'
+          @customer_properties_serializer.constantize
+        end
+
+        def payload_serializer
+          @payload_serializer.constantize
+        end
+      end
+
       def initialize(payload = {})
         @payload = payload
       end

--- a/lib/solidus_tracking/event/cancelled_order.rb
+++ b/lib/solidus_tracking/event/cancelled_order.rb
@@ -3,6 +3,8 @@
 module SolidusTracking
   module Event
     class CancelledOrder < Base
+      self.payload_serializer = '::SolidusTracking::Serializer::Order'
+
       def name
         'Cancelled Order'
       end
@@ -10,11 +12,11 @@ module SolidusTracking
       delegate :email, to: :order
 
       def customer_properties
-        Serializer::CustomerProperties.serialize(order.user || order.email)
+        self.class.customer_properties_serializer.serialize(order.user || order.email)
       end
 
       def properties
-        Serializer::Order.serialize(order).merge(
+        self.class.payload_serializer.serialize(order).merge(
           '$event_id' => order.number,
           '$value' => order.total,
         )

--- a/lib/solidus_tracking/event/created_account.rb
+++ b/lib/solidus_tracking/event/created_account.rb
@@ -3,6 +3,8 @@
 module SolidusTracking
   module Event
     class CreatedAccount < Base
+      self.payload_serializer = '::SolidusTracking::Serializer::User'
+
       def name
         'Created Account'
       end
@@ -10,11 +12,11 @@ module SolidusTracking
       delegate :email, to: :user
 
       def customer_properties
-        Serializer::CustomerProperties.serialize(user)
+        self.class.customer_properties_serializer.serialize(user)
       end
 
       def properties
-        Serializer::User.serialize(user).merge(
+        self.class.payload_serializer.serialize(user).merge(
           '$event_id' => "#{user.id}-#{user.created_at.to_i}",
         )
       end

--- a/lib/solidus_tracking/event/fulfilled_order.rb
+++ b/lib/solidus_tracking/event/fulfilled_order.rb
@@ -3,6 +3,8 @@
 module SolidusTracking
   module Event
     class FulfilledOrder < Base
+      self.payload_serializer = '::SolidusTracking::Serializer::Order'
+
       def name
         'Fulfilled Order'
       end
@@ -10,11 +12,11 @@ module SolidusTracking
       delegate :email, to: :order
 
       def customer_properties
-        Serializer::CustomerProperties.serialize(order.user || order.email)
+        self.class.customer_properties_serializer.serialize(order.user || order.email)
       end
 
       def properties
-        Serializer::Order.serialize(order).merge(
+        self.class.payload_serializer.serialize(order).merge(
           '$event_id' => order.number,
           '$value' => order.total,
         )

--- a/lib/solidus_tracking/event/ordered_product.rb
+++ b/lib/solidus_tracking/event/ordered_product.rb
@@ -3,6 +3,8 @@
 module SolidusTracking
   module Event
     class OrderedProduct < Base
+      self.payload_serializer = '::SolidusTracking::Serializer::LineItem'
+
       def name
         'Ordered Product'
       end
@@ -12,11 +14,11 @@ module SolidusTracking
       end
 
       def customer_properties
-        Serializer::CustomerProperties.serialize(line_item.order.user || line_item.order.email)
+        self.class.customer_properties_serializer.serialize(line_item.order.user || line_item.order.email)
       end
 
       def properties
-        Serializer::LineItem.serialize(line_item).merge(
+        self.class.payload_serializer.serialize(line_item).merge(
           '$event_id' => "#{line_item.order.number}-#{line_item.id}",
           '$value' => line_item.amount,
         )

--- a/lib/solidus_tracking/event/placed_order.rb
+++ b/lib/solidus_tracking/event/placed_order.rb
@@ -3,6 +3,8 @@
 module SolidusTracking
   module Event
     class PlacedOrder < Base
+      self.payload_serializer = '::SolidusTracking::Serializer::Order'
+
       def name
         'Placed Order'
       end
@@ -10,11 +12,11 @@ module SolidusTracking
       delegate :email, to: :order
 
       def customer_properties
-        Serializer::CustomerProperties.serialize(order.user || order.email)
+        self.class.customer_properties_serializer.serialize(order.user || order.email)
       end
 
       def properties
-        Serializer::Order.serialize(order).merge(
+        self.class.payload_serializer.serialize(order).merge(
           '$event_id' => order.number,
           '$value' => order.total,
         )

--- a/lib/solidus_tracking/event/reset_password.rb
+++ b/lib/solidus_tracking/event/reset_password.rb
@@ -3,6 +3,8 @@
 module SolidusTracking
   module Event
     class ResetPassword < Base
+      self.payload_serializer = '::SolidusTracking::Serializer::User'
+
       def name
         'Reset Password'
       end
@@ -10,11 +12,11 @@ module SolidusTracking
       delegate :email, to: :user
 
       def customer_properties
-        Serializer::CustomerProperties.serialize(user)
+        self.class.customer_properties_serializer.serialize(user)
       end
 
       def properties
-        Serializer::User.serialize(user).merge(
+        self.class.payload_serializer.serialize(user).merge(
           '$event_id' => "#{user.id}-#{user.reset_password_sent_at.to_i}",
           'PasswordResetToken' => token,
           'PasswordResetURL' => password_reset_url,

--- a/lib/solidus_tracking/event/started_checkout.rb
+++ b/lib/solidus_tracking/event/started_checkout.rb
@@ -3,6 +3,8 @@
 module SolidusTracking
   module Event
     class StartedCheckout < Base
+      self.payload_serializer = '::SolidusTracking::Serializer::Order'
+
       def name
         'Started Checkout'
       end
@@ -10,11 +12,11 @@ module SolidusTracking
       delegate :email, to: :order
 
       def customer_properties
-        Serializer::CustomerProperties.serialize(order.user || order.email)
+        self.class.customer_properties_serializer.serialize(order.user || order.email)
       end
 
       def properties
-        Serializer::Order.serialize(order).merge(
+        self.class.payload_serializer.serialize(order).merge(
           '$event_id' => order.number,
           '$value' => order.total,
         )


### PR DESCRIPTION
With this PR, we allow payload and customer properties serializers to be configured on a per-event basis, while also providing instructions on how to change them globally. This allows more granular control on serializer configuration and spares the user the need to use decorators to change the serializer on an existing event.