### PR TITLE
Fix serializer classes not being inherited

### DIFF
--- a/lib/solidus_tracking/event/base.rb
+++ b/lib/solidus_tracking/event/base.rb
@@ -9,11 +9,19 @@ module SolidusTracking
         attr_writer :customer_properties_serializer, :payload_serializer
 
         def customer_properties_serializer
+          if !@customer_properties_serializer && superclass < SolidusTracking::Event::Base
+            @customer_properties_serializer = superclass.customer_properties_serializer.name
+          end
+
           @customer_properties_serializer ||= '::SolidusTracking::Serializer::CustomerProperties'
           @customer_properties_serializer.constantize
         end
 
         def payload_serializer
+          if !@payload_serializer && superclass < SolidusTracking::Event::Base
+            @payload_serializer = superclass.payload_serializer.name
+          end
+
           @payload_serializer.constantize
         end
       end

--- a/spec/solidus_tracking/event/base_spec.rb
+++ b/spec/solidus_tracking/event/base_spec.rb
@@ -1,0 +1,68 @@
+RSpec.describe SolidusTracking::Event::Base do
+  describe '.payload_serializer' do
+    context 'when the event does not have a payload serializer but the parent does' do
+      it "returns the parent's payload serializer" do
+        stub_const('ParentSerializer', Class.new(SolidusTracking::Serializer::Base))
+        stub_const('ParentEvent', Class.new(described_class) do
+          self.payload_serializer = 'ParentSerializer'
+        end)
+        stub_const('ChildEvent', Class.new(ParentEvent))
+
+        expect(ChildEvent.payload_serializer).to eq(ParentSerializer)
+      end
+    end
+
+    context 'when both the event and the parent have a payload serializer' do
+      it "returns the event's payload serializer" do
+        stub_const('ParentSerializer', Class.new(SolidusTracking::Serializer::Base))
+        stub_const('ParentEvent', Class.new(described_class) do
+          self.payload_serializer = 'ParentSerializer'
+        end)
+        stub_const('ChildSerializer', Class.new(SolidusTracking::Serializer::Base))
+        stub_const('ChildEvent', Class.new(ParentEvent) do
+          self.payload_serializer = 'ChildSerializer'
+        end)
+
+        expect(ChildEvent.payload_serializer).to eq(ChildSerializer)
+      end
+    end
+  end
+
+  describe '.customer_properties_serializer' do
+    context 'when the event does not have a customer properties serializer but the parent does' do
+      it "returns the parent's customer properties serializer" do
+        stub_const('ParentSerializer', Class.new(SolidusTracking::Serializer::Base))
+        stub_const('ParentEvent', Class.new(described_class) do
+          self.customer_properties_serializer = 'ParentSerializer'
+        end)
+        stub_const('ChildEvent', Class.new(ParentEvent))
+
+        expect(ChildEvent.customer_properties_serializer).to eq(ParentSerializer)
+      end
+    end
+
+    context 'when both the event and the parent have a customer properties serializer' do
+      it "returns the event's customer properties serializer" do
+        stub_const('ParentSerializer', Class.new(SolidusTracking::Serializer::Base))
+        stub_const('ParentEvent', Class.new(described_class) do
+          self.customer_properties_serializer = 'ParentSerializer'
+        end)
+        stub_const('ChildSerializer', Class.new(SolidusTracking::Serializer::Base))
+        stub_const('ChildEvent', Class.new(ParentEvent) do
+          self.customer_properties_serializer = 'ChildSerializer'
+        end)
+
+        expect(ChildEvent.customer_properties_serializer).to eq(ChildSerializer)
+      end
+    end
+
+    context 'when nor the event nor the parent have a customer properties serializer' do
+      it "returns the default customer properties serializer" do
+        stub_const('ParentEvent', Class.new(described_class))
+        stub_const('ChildEvent', Class.new(ParentEvent))
+
+        expect(ChildEvent.customer_properties_serializer).to eq(SolidusTracking::Serializer::CustomerProperties)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Fixes an issue that was forcing us to specify `payload_serializer` and `customer_properties_serializer` every time we inherited from `SolidusTracking::Event::Base` or a child. Now, the serializer classes are looked up the ancestors chain if they are not defined directly on the current event class.