### PR TITLE
Allow disabling automatic tracking for certain events

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ the case), you can loop through the `.events` setting:
 # config/initializers/solidus_tracking.rb
 
 SolidusTracking.configuration.events.each_value do |event_klass|
-  event_klass.customer_properties_serializer = 'MyApp::Serializers::CustomerProperties'
+  event_klass.constantize.customer_properties_serializer = 'MyApp::Serializers::CustomerProperties'
 end
 ```
 
@@ -175,6 +175,28 @@ This will disable the following emails:
 - Carton shipped
 
 You'll have to re-implement the emails with a tracker.
+
+### Disabling automatic event tracking
+
+If you want to disable the out-of-the-box event tracking, you can do so on a per-event basis by
+acting on the `automatic_events` configuration option:
+
+```ruby
+# config/initializers/solidus_tracking.rb
+SolidusTracking.configure do |config|
+  config.automatic_events.delete('placed_order')
+end
+```
+
+You may also disable the built-in event tracking completely, if you only want to track events
+manually:
+
+```ruby
+# config/initializers/solidus_tracking.rb
+SolidusTracking.configure do |config|
+  config.automatic_events.clear
+end
+```
 
 ### Test mode
 

--- a/app/decorators/models/solidus_tracking/spree/order/track_order_fulfillment.rb
+++ b/app/decorators/models/solidus_tracking/spree/order/track_order_fulfillment.rb
@@ -13,7 +13,7 @@ module SolidusTracking
         def track_fulfilled_order
           return unless previous_changes.key?('shipment_state') && shipment_state == 'shipped'
 
-          SolidusTracking.track_later('fulfilled_order', order: self)
+          SolidusTracking.automatic_track_later('fulfilled_order', order: self)
         end
       end
     end

--- a/app/decorators/models/solidus_tracking/spree/order/track_order_lifecycle.rb
+++ b/app/decorators/models/solidus_tracking/spree/order/track_order_lifecycle.rb
@@ -14,21 +14,21 @@ module SolidusTracking
         private
 
         def track_started_checkout
-          SolidusTracking.track_later('started_checkout', order: self)
+          SolidusTracking.automatic_track_later('started_checkout', order: self)
         end
 
         def track_ordered_product
           line_items.each do |line_item|
-            SolidusTracking.track_later('ordered_product', line_item: line_item)
+            SolidusTracking.automatic_track_later('ordered_product', line_item: line_item)
           end
         end
 
         def track_placed_order
-          SolidusTracking.track_later('placed_order', order: self)
+          SolidusTracking.automatic_track_later('placed_order', order: self)
         end
 
         def track_cancelled_order
-          SolidusTracking.track_later('cancelled_order', order: self)
+          SolidusTracking.automatic_track_later('cancelled_order', order: self)
         end
       end
     end

--- a/app/decorators/models/solidus_tracking/spree/user/track_password_reset.rb
+++ b/app/decorators/models/solidus_tracking/spree/user/track_password_reset.rb
@@ -6,7 +6,7 @@ module SolidusTracking
       module TrackPasswordReset
         def send_reset_password_instructions
           token = super
-          SolidusTracking.track_later('reset_password', user: self, token: token)
+          SolidusTracking.automatic_track_later('reset_password', user: self, token: token)
           token
         end
       end

--- a/app/decorators/models/solidus_tracking/spree/user/track_signup.rb
+++ b/app/decorators/models/solidus_tracking/spree/user/track_signup.rb
@@ -11,7 +11,7 @@ module SolidusTracking
         private
 
         def track_signup
-          SolidusTracking.track_later 'created_account', user: self
+          SolidusTracking.automatic_track_later 'created_account', user: self
         end
       end
     end

--- a/lib/generators/solidus_tracking/install/templates/initializer.rb
+++ b/lib/generators/solidus_tracking/install/templates/initializer.rb
@@ -45,8 +45,11 @@ SolidusTracking.configure do |config|
   config.disable_builtin_emails = false
 
   # You can register custom events or override the defaults by manipulating the `events` hash.
-  # config.events['my_custom_event'] = MyApp::Events::MyCustomEvent
-  # config.events['placed_order'] = MyApp::Events::PlacedOrder
+  # config.events['my_custom_event'] = 'MyApp::Events::MyCustomEvent'
+  # config.events['placed_order'] = 'MyApp::Events::PlacedOrder'
+
+  # You can disable automatic tracking for any of the built-in events here.
+  # config.automatic_events.delete('placed_order')
 
   # In test mode, all calls to `#track_now` and `#subscribe_now` are recorded and their
   # responses are mocked.

--- a/lib/solidus_tracking.rb
+++ b/lib/solidus_tracking.rb
@@ -57,6 +57,12 @@ module SolidusTracking
       SolidusTracking::TrackEventJob.perform_later(event_name, event_payload)
     end
 
+    def automatic_track_later(event_name, event_payload = {})
+      return unless configuration.automatic_events.include?(event_name)
+
+      track_later(event_name, event_payload)
+    end
+
     private
 
     def test_registry

--- a/lib/solidus_tracking/configuration.rb
+++ b/lib/solidus_tracking/configuration.rb
@@ -2,6 +2,16 @@
 
 module SolidusTracking
   class Configuration
+    BUILT_IN_EVENTS = {
+      'ordered_product' => 'SolidusTracking::Event::OrderedProduct',
+      'placed_order' => 'SolidusTracking::Event::PlacedOrder',
+      'started_checkout' => 'SolidusTracking::Event::StartedCheckout',
+      'cancelled_order' => 'SolidusTracking::Event::CancelledOrder',
+      'reset_password' => 'SolidusTracking::Event::ResetPassword',
+      'created_account' => 'SolidusTracking::Event::CreatedAccount',
+      'fulfilled_order' => 'SolidusTracking::Event::FulfilledOrder',
+    }.freeze
+
     attr_accessor(
       :variant_url_builder, :image_url_builder, :password_reset_url_builder, :order_url_builder,
       :disable_builtin_emails, :test_mode,
@@ -16,19 +26,16 @@ module SolidusTracking
     end
 
     def events
-      @events ||= {
-        'ordered_product' => SolidusTracking::Event::OrderedProduct,
-        'placed_order' => SolidusTracking::Event::PlacedOrder,
-        'started_checkout' => SolidusTracking::Event::StartedCheckout,
-        'cancelled_order' => SolidusTracking::Event::CancelledOrder,
-        'reset_password' => SolidusTracking::Event::ResetPassword,
-        'created_account' => SolidusTracking::Event::CreatedAccount,
-        'fulfilled_order' => SolidusTracking::Event::FulfilledOrder,
-      }
+      @events ||= BUILT_IN_EVENTS.dup
+    end
+
+    def automatic_events
+      @automatic_events ||= BUILT_IN_EVENTS.keys
     end
 
     def event_klass(name)
-      events[name.to_s]
+      klass = events[name.to_s]
+      klass.is_a?(String) ? klass.constantize : klass
     end
 
     def event_klass!(name)


### PR DESCRIPTION
Allows extension users to disable the built-in event tracking functionality. This is useful when users want to track certain or all events manually, because their build is too custom to work with the standard hooks used by solidus_tracking.