### PR TITLE
Fix serializer for order with promotions

### DIFF
--- a/lib/solidus_tracking/serializer/order.rb
+++ b/lib/solidus_tracking/serializer/order.rb
@@ -14,7 +14,7 @@ module SolidusTracking
             line_item.variant.product.taxons.flat_map(&:self_and_ancestors)
           end).uniq.map(&:name),
           'ItemNames' => order.line_items.map { |line_item| line_item.variant.descriptive_name },
-          'DiscountCode' => order.order_promotions.map { |op| op.code.value }.join(', '),
+          'DiscountCode' => order.order_promotions.map { |op| op.promotion_code.value }.join(', '),
           'DiscountValue' => order.promo_total,
           'Items' => order.line_items.map { |line_item| LineItem.serialize(line_item) },
           'BillingAddress' => Address.serialize(order.bill_address),

--- a/spec/solidus_tracking/serializer/order_spec.rb
+++ b/spec/solidus_tracking/serializer/order_spec.rb
@@ -3,7 +3,7 @@
 RSpec.describe SolidusTracking::Serializer::Order do
   describe '.serialize' do
     it 'serializes the order' do
-      order = build_stubbed(:completed_order_with_totals)
+      order = create(:completed_order_with_promotion)
 
       expect(described_class.serialize(order)).to be_instance_of(Hash)
     end


### PR DESCRIPTION
Fixes #15 

This fixes a bug where we called a wrong (missing) method to get the order promotion codes.

To avoid regressions, this also slightly alters the specs by persisting the order in the database, by also creating all the required associations to cascade the serialization logic onto them.