### PR TITLE
Update order serializer to handle promotions correctly

### DIFF
--- a/lib/solidus_tracking/serializer/order.rb
+++ b/lib/solidus_tracking/serializer/order.rb
@@ -14,7 +14,7 @@ module SolidusTracking
             line_item.variant.product.taxons.flat_map(&:self_and_ancestors)
           end).uniq.map(&:name),
           'ItemNames' => order.line_items.map { |line_item| line_item.variant.descriptive_name },
-          'DiscountCode' => order.order_promotions.map { |op| op.promotion_code.value }.join(', '),
+          'DiscountCode' => order.adjustments.promotion.eligible.map { |op| op.promotion_code ? op.promotion_code.value : "all orders" }.join(', '),
           'DiscountValue' => order.promo_total,
           'Items' => order.line_items.map { |line_item| LineItem.serialize(line_item) },
           'BillingAddress' => Address.serialize(order.bill_address),

--- a/spec/solidus_tracking/serializer/order_spec.rb
+++ b/spec/solidus_tracking/serializer/order_spec.rb
@@ -7,5 +7,24 @@ RSpec.describe SolidusTracking::Serializer::Order do
 
       expect(described_class.serialize(order)).to be_instance_of(Hash)
     end
+
+    it 'uses default promotion code to promotions that apply to all orders' do
+      promotion = create(:promotion_with_order_adjustment, apply_automatically: true)
+      order = create(:order)
+
+      promotion.activate(order: order)
+
+      expect(described_class.serialize(order)).to include({"DiscountCode" => "all orders"})
+    end
+
+    it 'does not include ineligible discount codes' do
+      promotions = Array.new(2) { create(:promotion_with_order_adjustment, apply_automatically: true) }
+      order = create(:order)
+
+      promotions.each { |promo| promo.activate(order: order) }
+      order.updater.update
+
+      expect(described_class.serialize(order)["DiscountCode"]).not_to include("all orders, all orders")
+    end
   end
 end


### PR DESCRIPTION
Previously, the order serializer would pull in all promotions regardless
of whether they were eligible or not and display the promotion_code.
This also causes breakage with order promotions that apply to all orders,
as those promotions do not have promotion_codes.

This only displays eligible promotions in the serializer, and if no
promotion code exists, will set the promotion code to "all orders".